### PR TITLE
fix: Resolve problems with `<center>` in markdown 3.8

### DIFF
--- a/docs/rvpn.md
+++ b/docs/rvpn.md
@@ -24,7 +24,7 @@ counter: True
 进入网站 [myvpn.zju.edu.cn](https://myvpn.zju.edu.cn/) 或者通过浙大钉—工作台—全部—网络缴费进入信息技术中心网站，这里将浙大钉换为钉钉也可以。
 
 !!! Note "网页版激活界面"
-    <center>![](images/activate.png)</center>
+    <figure markdown="1">![](images/activate.png)</figure>
 
 第一次使用 VPN 之前先要激活账号，点击“激活账号”可跳转到浙江大学统一身份认证并激活（可能会用到校园卡密码，身份证后六位）。
 
@@ -57,11 +57,11 @@ WebVPN 是一种通过网页跳转来实现外网访问内网的连接方式，�
 
 首先进入 [webvpn.zju.edu.cn](https://webvpn.zju.edu.cn/)，可以看到以下界面，然后输入用户名及网络密码并登录，这里的网络密码可能与统一身份认证密码不同。
 
-<center>![](images/WebVPN-1.png)</center>
+<figure markdown="1">![](images/WebVPN-1.png)</figure>
 
 成功登录后，在以下界面红框所圈的搜索框输入要访问的学校网址即可。（例如 [cc98.org](https://www.cc98.org/)）
 
-<center>![](images/WebVPN-2.png)</center>
+<figure markdown="1">![](images/WebVPN-2.png)</figure>
 
 
 ### VPN
@@ -82,7 +82,7 @@ WebVPN 是一种通过网页跳转来实现外网访问内网的连接方式，�
 ZJUWLAN 在 Wi-Fi 里可以直接找到并连接，但是需要认证，一般在连接后会弹出认证窗口，在填写好用户名、密码后，即可正常上网。一次认证有效时长为 14 天，到期后需要重新认证。
 
 !!! Note "网页版认证界面"
-    <center>![](images/net3_zju.png)</center>
+    <figure markdown="1">![](images/net3_zju.png)</figure>
 
 如果没有弹出的话也可以直接访问 [net3.zju.edu.cn](http://net3.zju.edu.cn)，进入认证界面。
 
@@ -92,21 +92,21 @@ ZJUWLAN-Secure 在连接时，在输入所用的用户名、密码后即可完�
     点击桌面右下方菜单栏中的无线网图标，选择 ZJUWLAN-Secure 进行连接，在输入用户名及密码后，点击连接后即可上网。
     ???+ General "操作步骤"
         === "Step 1"
-            <center>![](images/ZJUWLAN-Secure-Windows-1.png)</center>
+            <figure markdown="1">![](images/ZJUWLAN-Secure-Windows-1.png)</figure>
         === "Step 2"
-            <center>![](images/ZJUWLAN-Secure-Windows-2.png)</center>
+            <figure markdown="1">![](images/ZJUWLAN-Secure-Windows-2.png)</figure>
         === "Step 3"
-            <center>![](images/ZJUWLAN-Secure-Windows-3.png)</center>
+            <figure markdown="1">![](images/ZJUWLAN-Secure-Windows-3.png)</figure>
         === "Step 4"
-            <center>![](images/ZJUWLAN-Secure-Windows-4.png)</center>
+            <figure markdown="1">![](images/ZJUWLAN-Secure-Windows-4.png)</figure>
 
 === "Android"
     在手机中进入 WLAN 连接页面，选择 ZJUWLAN-Secure 进行连接，之后的阶段 2 身份认证和 CA 证书均选择**不认证**，在输入用户名和密码后，点击连接即可。
     ???+ General "操作步骤"
         === "Step 1"
-            <center>![](images/ZJUWLAN-Secure-Android-1.jpg)</center>
+            <figure markdown="1">![](images/ZJUWLAN-Secure-Android-1.jpg)</figure>
         === "Step 2"
-            <center>![](images/ZJUWLAN-Secure-Android-2.jpg)</center>
+            <figure markdown="1">![](images/ZJUWLAN-Secure-Android-2.jpg)</figure>
 
 ### 有线连接
 


### PR DESCRIPTION
<img width="1415" height="352" alt="image" src="https://github.com/user-attachments/assets/ade77f7b-1a91-471f-b9a8-f69da6c63ec4" />

Since `markdown` v3.8, the behavior of `<center>` rendering is changed (indeed corrected). And *those who relied on the improper handling of this deprecated tag previous to 3.8 will see surprising differences*. [markdown/docs/changelog.md at master · Python-Markdown/markdown](https://github.com/Python-Markdown/markdown/blob/master/docs/changelog.md#380---2025-04-09) 

This PR intends to to resolve it.
